### PR TITLE
Simplify native compilation with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
 all: compile xref eunit dialyze edoc
 
+rebar ?= ./rebar3
+rebar_cmd = $(rebar) $(profile:%=as %)
+
 compile:
-	@./rebar3 compile
+	@$(rebar_cmd) compile
 
 xref:
-	@./rebar3 xref
+	@$(rebar_cmd) xref
 
 clean:
-	@./rebar3 clean
+	@$(rebar_cmd) clean
 
 eunit:
-	@./rebar3 do eunit,cover
+	@$(rebar_cmd) do eunit,cover
 
+edoc: profile=edown
 edoc:
-	@./rebar3 as edown edoc
+	@$(rebar_cmd) edoc
 
 start: compile
-	@./rebar3 shell
+	-@$(rebar_cmd) shell
 
 dialyze: compile
-	@./rebar3 dialyzer
+	@$(rebar_cmd) dialyzer

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ If you want to use HiPE compiled version, please add following code to your reba
   ]}.
 ```
 
+or use `native` profile. The `make` command supports profile as well. For example:
+
+```sh
+$ make start profile=native
+```
+
 Usage Example
 -------------
 

--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,10 @@
 
 {profiles,
  [
+  {native,
+   [
+    {erl_opts, [{d, 'ENABLE_HIPE'}]}
+   ]},
   {edown,
    [
     {edoc_opts,


### PR DESCRIPTION
This patch allows define profiles in `make` command line. For example:

```
$ make start profile=native
```

As a side effect, it also allows use custom `rebar3`. For example system wide `rebar3`:

```
$ make compile rebar=`which rebar3` profile=native
```