### PR TITLE
Support datetime with fractions of seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,28 +171,31 @@ Data Mapping (Erlang <=> JSON)
 Erlang                  JSON             Erlang
 =================================================================================================
 
-null                 -> null                   -> null
-true                 -> true                   -> true
-false                -> false                  -> false
-<<"abc">>            -> "abc"                  -> <<"abc">>
-abc                  -> "abc"                  -> <<"abc">> % non-special atom is regarded as a binary
-{{2010,1,1},{0,0,0}} -> "2010-01-01T00:00:00Z" -> <<"2010-01-01T00:00:00Z">> % datetime (see: `jsone:datetime_encode_format/0`)
-123                  -> 123                    -> 123
-123.4                -> 123.4                  -> 123.4
-[1,2,3]              -> [1,2,3]                -> [1,2,3]
-{[]}                 -> {}                     -> {[]}                       % object_format=tuple
-{[{key, <<"val">>}]} -> {"key":"val"}          -> {[{<<"key">>, <<"val">>}]} % object_format=tuple
-[{}]                 -> {}                     -> [{}]                       % object_format=proplist
-[{<<"key">>, val}]   -> {"key":"val"}          -> [{<<"key">>, <<"val">>}]   % object_format=proplist
-#{}                  -> {}                     -> #{}                        % object_format=map
-#{key => val}        -> {"key":"val"}          -> #{<<"key">> => <<"val">>}  % object_format=map
-{json, IOList}       -> Value                  -> ~~~                        % UTF-8 encoded term
-{json_utf8, Chars}   -> Value                  -> ~~~                        % Unicode code points
+null                   -> null                       -> null
+true                   -> true                       -> true
+false                  -> false                      -> false
+<<"abc">>              -> "abc"                      -> <<"abc">>
+abc                    -> "abc"                      -> <<"abc">> % non-special atom is regarded as a binary
+{{2010,1,1},{0,0,0}}   -> "2010-01-01T00:00:00Z"     -> <<"2010-01-01T00:00:00Z">>     % datetime*
+{{2010,1,1},{0,0,0.0}} -> "2010-01-01T00:00:00.000Z" -> <<"2010-01-01T00:00:00.000Z">> % datetime*
+123                    -> 123                        -> 123
+123.4                  -> 123.4                      -> 123.4
+[1,2,3]                -> [1,2,3]                    -> [1,2,3]
+{[]}                   -> {}                         -> {[]}                       % object_format=tuple
+{[{key, <<"val">>}]}   -> {"key":"val"}              -> {[{<<"key">>, <<"val">>}]} % object_format=tuple
+[{}]                   -> {}                         -> [{}]                       % object_format=proplist
+[{<<"key">>, val}]     -> {"key":"val"}              -> [{<<"key">>, <<"val">>}]   % object_format=proplist
+#{}                    -> {}                         -> #{}                        % object_format=map
+#{key => val}          -> {"key":"val"}              -> #{<<"key">> => <<"val">>}  % object_format=map
+{json, IOList}         -> Value                      -> ~~~                        % UTF-8 encoded term**
+{json_utf8, Chars}     -> Value                      -> ~~~                        % Unicode code points**
 ```
 
-`{json, IOList} and {json_utf8, Chars} allows inline already encoded JSON
+\* see [jsone:datetime_encode_format()](doc/jsone.md#type-datetime_encode_format)
+
+\** `{json, IOList}` and `{json_utf8, Chars}` allows inline already encoded JSON
 values. For example, you obtain JSON encoded data from database so you don't
-have to decode it first and encode again. See [json_term()](doc/jsone.md#type-json_term).
+have to decode it first and encode again. See [jsone:json_term()](doc/jsone.md#type-json_term).
 
 API
 ---

--- a/src/jsone_encode.erl
+++ b/src/jsone_encode.erl
@@ -156,11 +156,14 @@ datetime({{Y,M,D}, {H,Mi,S}}, Nexts, Buf, Opt) when ?IS_DATETIME(Y,M,D,H,Mi,S) -
 datetime(Datetime, Nexts, Buf, Opt) ->
     ?ERROR(datetime, [Datetime, Nexts, Buf, Opt]).
 
+-dialyzer({no_improper_lists, [format_year/1]}).
+-spec format_year(non_neg_integer()) -> iodata().
 format_year(Y) when Y > 999 -> integer_to_binary(Y);
 format_year(Y) ->
     B = integer_to_binary(Y),
     [lists:duplicate(4-byte_size(B), $0)|B].
 
+-spec format2digit(non_neg_integer()) -> iolist().
 format2digit(0) -> "00";
 format2digit(1) -> "01";
 format2digit(2) -> "02";
@@ -173,15 +176,18 @@ format2digit(8) -> "08";
 format2digit(9) -> "09";
 format2digit(X) -> integer_to_list(X).
 
+-spec format_seconds(non_neg_integer() | float()) -> iolist().
 format_seconds(S) when is_integer(S) -> format2digit(S);
 format_seconds(S) when is_float(S) -> io_lib:format("~6.3.0f", [S]).
 
+-spec format_tz(integer()) -> byte() | iolist().
 format_tz(0) -> $Z;
 format_tz(Tz) when Tz > 0 -> [$+|format_tz_(Tz)];
 format_tz(Tz) -> [$-|format_tz_(-Tz)].
 
 -define(SECONDS_PER_MINUTE, 60).
 -define(SECONDS_PER_HOUR, 3600).
+-spec format_tz_(integer()) -> iolist().
 format_tz_(S) ->
     H = S div ?SECONDS_PER_HOUR,
     S1 = S rem ?SECONDS_PER_HOUR,

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -145,6 +145,14 @@ encode_test_() ->
               ?assertEqual({ok, <<"\"2015-06-25T14:57:25-00:01\"">>}, jsone_encode:encode({{2015,6,25},{14,57,25}}, [{datetime_format, {iso8601, -60}}]))
       end},
 
+     {"datetime: iso8601: with fractions of seconds",
+      fun () ->
+              ?assertEqual({ok, <<"\"2015-06-25T14:57:25.325Z\"">>},
+                           jsone_encode:encode({{2015,6,25},{14,57,25.3245}})),
+              ?assertEqual({ok, <<"\"2015-06-25T14:57:05.320Z\"">>},
+                           jsone_encode:encode({{2015,6,25},{14,57,5.32}}))
+      end},
+
      %% Arrays
      {"simple array",
       fun () ->


### PR DESCRIPTION
From `epgsql` you can obtain timestamp with float value of seconds. ISO 8601 allows variant with HH:MM:SS.SSS so this patch adds it for timestamps with float seconds.

DateTime formatting is also rewritten faster (6x BEAM and 9x HiPE) and more memory friendly.