### PR TITLE
Add jsx compatible keys/labels option for object keys atom conversion

### DIFF
--- a/doc/jsone.md
+++ b/doc/jsone.md
@@ -60,7 +60,7 @@ datetime_format() = iso8601
 
 
 <pre><code>
-decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, boolean()} | {keys | labels, binary | atom | existing_atom | attempt_atom}
+decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, boolean()} | {keys, binary | atom | existing_atom | attempt_atom}
 </code></pre>
 
 `object_format`: <br />
@@ -76,7 +76,7 @@ decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, b
 
 `keys`: <br />
 Defines way how object keys are decoded. The default value is `binary`.
-`labels` is alias compatible with `jsx`. <br />
+The option is compatible with `labels` option in `jsx`. <br />
 - `binary`: The key is left as a string which is encoded as binary. It's default
 and backward compatible behaviour. <br />
 - `atom`: The key is converted to an atom. Results in `badarg` if Key value

--- a/doc/jsone.md
+++ b/doc/jsone.md
@@ -60,7 +60,7 @@ datetime_format() = iso8601
 
 
 <pre><code>
-decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, boolean()}
+decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, boolean()} | {keys | labels, binary | atom | existing_atom | attempt_atom}
 </code></pre>
 
 `object_format`: <br />
@@ -73,6 +73,18 @@ decode_option() = {object_format, tuple | proplist | map} | {allow_ctrl_chars, b
 `allow_ctrl_chars`: <br />
 - If the value is `true`, strings which contain ununescaped control characters will be regarded as a legal JSON string <br />
 - default: `false`<br />
+
+`keys`: <br />
+Defines way how object keys are decoded. The default value is `binary`.
+`labels` is alias compatible with `jsx`. <br />
+- `binary`: The key is left as a string which is encoded as binary. It's default
+and backward compatible behaviour. <br />
+- `atom`: The key is converted to an atom. Results in `badarg` if Key value
+regarded as UTF-8 is not a valid atom. <br />
+- `existing_atom`: Returns existing atom. Any key value which is not
+existing atom raises `badarg` exception. <br />
+- `attempt_atom`: Returns existing atom as `existing_atom` but returns a
+binary string if fails find one.
 
 
 

--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -218,8 +218,7 @@
 
 -type decode_option() :: {object_format, tuple | proplist | map}
                        | {allow_ctrl_chars, boolean()}
-                       | {'keys' | 'labels', 'binary' | 'atom' |
-                          'existing_atom' | 'attempt_atom'}.
+                       | {'keys', 'binary' | 'atom' | 'existing_atom' | 'attempt_atom'}.
 %% `object_format': <br />
 %% - Decoded JSON object format <br />
 %% - `tuple': An object is decoded as `{[]}' if it is empty, otherwise `{[{Key, Value}]}'. <br />
@@ -233,7 +232,7 @@
 %%
 %% `keys': <br />
 %% Defines way how object keys are decoded. The default value is `binary'.
-%% `labels' is alias compatible with `jsx'. <br />
+%% The option is compatible with `labels' option in `jsx'. <br />
 %% - `binary': The key is left as a string which is encoded as binary. It's default
 %% and backward compatible behaviour. <br />
 %% - `atom': The key is converted to an atom. Results in `badarg' if Key value

--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -217,7 +217,9 @@
 %% - default: `0' <br />
 
 -type decode_option() :: {object_format, tuple | proplist | map}
-                       | {allow_ctrl_chars, boolean()}.
+                       | {allow_ctrl_chars, boolean()}
+                       | {'keys' | 'labels', 'binary' | 'atom' |
+                          'existing_atom' | 'attempt_atom'}.
 %% `object_format': <br />
 %% - Decoded JSON object format <br />
 %% - `tuple': An object is decoded as `{[]}' if it is empty, otherwise `{[{Key, Value}]}'. <br />
@@ -228,6 +230,18 @@
 %% `allow_ctrl_chars': <br />
 %% - If the value is `true', strings which contain ununescaped control characters will be regarded as a legal JSON string <br />
 %% - default: `false'<br />
+%%
+%% `keys': <br />
+%% Defines way how object keys are decoded. The default value is `binary'.
+%% `labels' is alias compatible with `jsx'. <br />
+%% - `binary': The key is left as a string which is encoded as binary. It's default
+%% and backward compatible behaviour. <br />
+%% - `atom': The key is converted to an atom. Results in `badarg' if Key value
+%% regarded as UTF-8 is not a valid atom. <br />
+%% - `existing_atom': Returns existing atom. Any key value which is not
+%% existing atom raises `badarg' exception. <br />
+%% - `attempt_atom': Returns existing atom as `existing_atom' but returns a
+%% binary string if fails find one.
 
 %%--------------------------------------------------------------------------------
 %% Exported Functions

--- a/src/jsone_decode.erl
+++ b/src/jsone_decode.erl
@@ -291,9 +291,6 @@ parse_option([{object_format,F}|T], Opt) when F =:= tuple; F =:= proplist; F =:=
     parse_option(T, Opt?OPT{object_format=F});
 parse_option([{allow_ctrl_chars,B}|T], Opt) when is_boolean(B) ->
     parse_option(T, Opt?OPT{allow_ctrl_chars=B});
-parse_option([{labels, K}|T], Opt)
-  when K =:= binary; K =:= atom; K =:= existing_atom; K =:= attempt_atom ->
-    parse_option(T, Opt?OPT{keys = K});
 parse_option([{keys, K}|T], Opt)
   when K =:= binary; K =:= atom; K =:= existing_atom; K =:= attempt_atom ->
     parse_option(T, Opt?OPT{keys = K});

--- a/test/jsone_decode_tests.erl
+++ b/test/jsone_decode_tests.erl
@@ -261,6 +261,23 @@ decode_test_() ->
               Input = <<"{\"1\":2 \"key\":\"value\"">>,
               ?assertMatch({error, {badarg, _}}, jsone_decode:decode(Input))
       end},
+     {"atom keys",
+      fun () ->
+              KeyOpt = fun(Keys) -> [{keys, Keys}, {object_format, proplist}]
+                       end,
+              Input = <<"{\"foo\":\"ok\"}">>,
+              ?assertEqual([{<<"foo">>, <<"ok">>}], jsone:decode(Input, KeyOpt(binary))),
+              ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, [{labels, atom}, {object_format, proplist}])),
+              ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, KeyOpt(atom))),
+              ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, KeyOpt(existing_atom))),
+              ?assertError(badarg, jsone:decode(<<"{\"@#$%^!\":\"ok\"}">>, KeyOpt(existing_atom))),
+              ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, KeyOpt(attempt_atom))),
+              ?assertEqual([{<<"@#$%^!">>, <<"ok">>}], jsone:decode(<<"{\"@#$%^!\":\"ok\"}">>, KeyOpt(attempt_atom))),
+              Value = integer_to_binary(rand:uniform(9999)),
+              % do not make atom in test code
+              [{Atom,  <<"ok">>}] = jsone:decode(<<"{\"", Value/binary, "\":\"ok\"}">>, KeyOpt(atom)),
+              ?assertEqual(Value, atom_to_binary(Atom, latin1))
+      end},
 
      %% Others
      {"compound data",

--- a/test/jsone_decode_tests.erl
+++ b/test/jsone_decode_tests.erl
@@ -267,7 +267,6 @@ decode_test_() ->
                        end,
               Input = <<"{\"foo\":\"ok\"}">>,
               ?assertEqual([{<<"foo">>, <<"ok">>}], jsone:decode(Input, KeyOpt(binary))),
-              ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, [{labels, atom}, {object_format, proplist}])),
               ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, KeyOpt(atom))),
               ?assertEqual([{foo, <<"ok">>}], jsone:decode(Input, KeyOpt(existing_atom))),
               ?assertError(badarg, jsone:decode(<<"{\"@#$%^!\":\"ok\"}">>, KeyOpt(existing_atom))),


### PR DESCRIPTION
The patch allows define `jsx` compatible atom as key decode option.