### PR TITLE
Add `native_forward_slash` encoding option

### DIFF
--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -189,6 +189,7 @@
 %% - Treats `undefined' in Erlang as the conversion target for `null' in JSON. This means that `undefined' will be encoded to `null' and `null' will be decoded to `undefined'<br />
 
 -type encode_option() :: native_utf8
+                       | native_slash
                        | canonical_form
                        | {float_format, [float_format_option()]}
                        | {datetime_format, datetime_encode_format()}
@@ -198,6 +199,9 @@
                        | common_option().
 %% `native_utf8': <br />
 %% - Encodes UTF-8 characters as a human-readable(non-escaped) string <br />
+%%
+%% `native_forward_slash': <br />
+%% - Prevents forward slashes in a JSON string from being escaped <br />
 %%
 %% `canonical_form': <br />
 %% - produce a canonical form of a JSON document <br />

--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -189,7 +189,7 @@
 %% - Treats `undefined' in Erlang as the conversion target for `null' in JSON. This means that `undefined' will be encoded to `null' and `null' will be decoded to `undefined'<br />
 
 -type encode_option() :: native_utf8
-                       | native_slash
+                       | native_forward_slash
                        | canonical_form
                        | {float_format, [float_format_option()]}
                        | {datetime_format, datetime_encode_format()}

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -104,6 +104,12 @@ encode_test_() ->
               ?assertEqual({ok, Expected}, jsone_encode:encode(Input)),
               ?assertEqual({ok, Expected}, jsone_encode:encode(Input, [native_utf8]))
       end},
+     {"string: contains forward slashes",
+      fun () ->
+              Input = <<"1/2">>,
+              ?assertEqual({ok, <<"\"1\\/2\"">>}, jsone_encode:encode(Input)),
+              ?assertEqual({ok, <<"\"1/2\"">>}, jsone_encode:encode(Input, [native_forward_slash]))
+      end},
      {"string: contains control characters",
       fun () ->
               Ctrls    = lists:seq(16#00, 16#1F) -- [$\b, $\f, $\n, $\r, $\t],


### PR DESCRIPTION
This PR adds `native_forward_slash` option for resolving the issue reported by #43.
