### PR TITLE
Prettify empty object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: erlang
 
 os: linux
 otp_release:
+  - 22.0
   - 21.0
   - 20.0
   - 19.3
-  - 18.3
-  - 17.5
-  - R16B03-1
 
 install:
   - sudo pip install codecov

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Usage Example
 <<"null">>
 
 %% Pretty Print
-> Data = [true, #{<<"1">> => 2, <<"array">> => [[[[1]]], #{<<"ab">> => <<"cd">>}, false]}, null].
-> io:format("~s\n", [jsone:encode(Data, [{indent, 1}, {space, 2}])]).
+> Data = [true, #{<<"1">> => 2, <<"array">> => [[[[1]]], #{<<"ab">> => <<"cd">>}, [], #{}, false]}, null].
+> io:format("~s\n", [jsone:encode(Data, [{indent, 2}, {space, 1}])]).
 [
   true,
   {
@@ -149,6 +149,8 @@ Usage Example
       {
         "ab": "cd"
       },
+      [],
+      {},
       false
     ]
   },

--- a/src/jsone_encode.erl
+++ b/src/jsone_encode.erl
@@ -303,6 +303,8 @@ hex(X) ->
           ).
 
 -spec array(jsone:json_array(), [next()], binary(), opt()) -> encode_result().
+array([],   Nexts, Buf, Opt) ->
+    next(Nexts, <<Buf/binary, $[, $]>>, Opt);
 array(List, Nexts, Buf, Opt) ->
     array_values(List, Nexts, pp_newline(<<Buf/binary, $[>>, Nexts, 1, Opt), Opt).
 
@@ -311,6 +313,8 @@ array_values([],       Nexts, Buf, Opt) -> next(Nexts, <<(pp_newline(Buf, Nexts,
 array_values([X | Xs], Nexts, Buf, Opt) -> value(X, [{array_values, Xs} | Nexts], Buf, Opt).
 
 -spec object(jsone:json_object_members(), [next()], binary(), opt()) -> encode_result().
+object([],      Nexts, Buf, Opt) ->
+    next(Nexts, <<Buf/binary, ${, $}>>, Opt);
 object(Members, Nexts, Buf, ?OPT{canonical_form = true}=Opt) ->
   object_members(lists:sort(Members), Nexts, pp_newline(<<Buf/binary, ${>>, Nexts, 1, Opt), Opt);
 object(Members, Nexts, Buf, Opt) ->

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -266,22 +266,28 @@ encode_test_() ->
      %% Pretty Print
      {"space",
       fun () ->
+              ?assertEqual({ok, <<"[]">>}, jsone_encode:encode([], [{space, 1}])),
               ?assertEqual({ok, <<"[1, 2, 3]">>}, jsone_encode:encode([1,2,3], [{space, 1}])),
               ?assertEqual({ok, <<"[1,  2,  3]">>}, jsone_encode:encode([1,2,3], [{space, 2}])),
+              ?assertEqual({ok, <<"{}">>}, jsone_encode:encode(?OBJ0, [{space, 1}])),
               ?assertEqual({ok, <<"{\"a\": 1, \"b\": 2}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{space, 1}])),
               ?assertEqual({ok, <<"{\"a\":  1,  \"b\":  2}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{space, 2}]))
       end},
      {"indent",
       fun () ->
+              ?assertEqual({ok, <<"[]">>}, jsone_encode:encode([], [{indent, 1}])),
               ?assertEqual({ok, <<"[\n 1,\n 2,\n 3\n]">>}, jsone_encode:encode([1,2,3], [{indent, 1}])),
               ?assertEqual({ok, <<"[\n  1,\n  2,\n  3\n]">>}, jsone_encode:encode([1,2,3], [{indent, 2}])),
+              ?assertEqual({ok, <<"{}">>}, jsone_encode:encode(?OBJ0, [{indent, 1}])),
               ?assertEqual({ok, <<"{\n \"a\":1,\n \"b\":2\n}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{indent, 1}])),
               ?assertEqual({ok, <<"{\n  \"a\":1,\n  \"b\":2\n}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{indent, 2}]))
       end},
      {"indent+space",
       fun () ->
+              ?assertEqual({ok, <<"[]">>}, jsone_encode:encode([], [{indent, 1}, {space, 1}])),
               ?assertEqual({ok, <<"[\n 1,\n 2,\n 3\n]">>}, jsone_encode:encode([1,2,3], [{indent, 1}, {space, 1}])),
               ?assertEqual({ok, <<"[\n  1,\n  2,\n  3\n]">>}, jsone_encode:encode([1,2,3], [{indent, 2}, {space, 2}])),
+              ?assertEqual({ok, <<"{}">>}, jsone_encode:encode(?OBJ0, [{indent, 1}, {space, 1}])),
               ?assertEqual({ok, <<"{\n \"a\": 1,\n \"b\": 2\n}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{indent, 1}, {space, 1}])),
               ?assertEqual({ok, <<"{\n  \"a\":  1,\n  \"b\":  2\n}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{indent, 2}, {space, 2}]))
       end},
@@ -289,11 +295,11 @@ encode_test_() ->
      %% Others
      {"compound data",
       fun () ->
-              Input    = [true, {[{<<"1">>, 2}, {<<"array">>, [[[[1]]], {[{<<"ab">>, <<"cd">>}]}, false]}]}, null],
-              Expected = <<"[true,{\"1\":2,\"array\":[[[[1]]],{\"ab\":\"cd\"},false]},null]">>,
+              Input    = [true, {[{<<"1">>, 2}, {<<"array">>, [[[[1]]], {[{<<"ab">>, <<"cd">>}]}, [], ?OBJ0, false]}]}, null],
+              Expected = <<"[true,{\"1\":2,\"array\":[[[[1]]],{\"ab\":\"cd\"},[],{},false]},null]">>,
               ?assertEqual({ok, Expected}, jsone_encode:encode(Input)),
 
-              PpExpected = <<"[\n true,\n {\n  \"1\": 2,\n  \"array\": [\n   [\n    [\n     [\n      1\n     ]\n    ]\n   ],\n   {\n    \"ab\": \"cd\"\n   },\n   false\n  ]\n },\n null\n]">>,
+              PpExpected = <<"[\n true,\n {\n  \"1\": 2,\n  \"array\": [\n   [\n    [\n     [\n      1\n     ]\n    ]\n   ],\n   {\n    \"ab\": \"cd\"\n   },\n   [],\n   {},\n   false\n  ]\n },\n null\n]">>,
               ?assertEqual({ok, PpExpected}, jsone_encode:encode(Input, [{indent, 1}, {space, 1}]))
       end},
      {"invalid value",


### PR DESCRIPTION
* Changing pretty-printed empty object and array into forms `{}` and `[]` to make them look easy on the eyes, comparing to forms:

```
{

}
```
```
[

]
```

* Update Travis coverage for ubuntu xenial
  * dropping 18.3 and older
  * adding 22.0