### PR TITLE
Add `map_unknown_value` encoding option

### DIFF
--- a/doc/jsone.md
+++ b/doc/jsone.md
@@ -120,7 +120,7 @@ the last such instance.
 
 
 <pre><code>
-encode_option() = native_utf8 | native_forward_slash | canonical_form | {float_format, [<a href="#type-float_format_option">float_format_option()</a>]} | {datetime_format, <a href="#type-datetime_encode_format">datetime_encode_format()</a>} | {object_key_type, string | scalar | value} | {space, non_neg_integer()} | {indent, non_neg_integer()} | <a href="#type-common_option">common_option()</a>
+encode_option() = native_utf8 | native_forward_slash | canonical_form | {float_format, [<a href="#type-float_format_option">float_format_option()</a>]} | {datetime_format, <a href="#type-datetime_encode_format">datetime_encode_format()</a>} | {object_key_type, string | scalar | value} | {space, non_neg_integer()} | {indent, non_neg_integer()} | {map_unknown_value, fun((term()) -&gt; {ok, <a href="#type-json_value">json_value()</a>} | error)} | <a href="#type-common_option">common_option()</a>
 </code></pre>
 
 `native_utf8`: <br />
@@ -155,6 +155,9 @@ encode_option() = native_utf8 | native_forward_slash | canonical_form | {float_f
 `{indent, N}`: <br />
 - Inserts a newline and `N` spaces for each level of indentation <br />
 - default: `0` <br />
+
+`{map_unknown_value, Fun}`: <br />
+- If specified, unknown values encountered during an encoding process are converted to `json_value()` by applying `Fun`.
 
 
 
@@ -233,7 +236,7 @@ json_object() = <a href="#type-json_object_format_tuple">json_object_format_tupl
 
 
 <pre><code>
-json_object_format_map() = map()
+json_object_format_map() = #{}
 </code></pre>
 
 
@@ -525,4 +528,3 @@ Encodes an erlang term into json text (a utf8 encoded binary)
                                 [hoge,[{array_values,[2]}],<<"[1,">>],
                                 [{line,86}]}]}}
 ```
-

--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -196,6 +196,7 @@
                        | {object_key_type, string | scalar | value}
                        | {space, non_neg_integer()}
                        | {indent, non_neg_integer()}
+                       | {map_unknown_value, fun ((term()) -> {ok, json_value()} | error)}
                        | common_option().
 %% `native_utf8': <br />
 %% - Encodes non ASCII UTF-8 characters as a human-readable(non-escaped) string <br />
@@ -229,6 +230,9 @@
 %% `{indent, N}': <br />
 %% - Inserts a newline and `N' spaces for each level of indentation <br />
 %% - default: `0' <br />
+%%
+%% `{map_unknown_value, Fun}`: <br />
+%% - If specified, unknown values encountered during an encoding process are converted to `json_value()` by applying `Fun'.
 
 -type decode_option() :: {object_format, tuple | proplist | map}
                        | {allow_ctrl_chars, boolean()}

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -292,6 +292,17 @@ encode_test_() ->
               ?assertEqual({ok, <<"{\n  \"a\":  1,\n  \"b\":  2\n}">>}, jsone_encode:encode(?OBJ2(a, 1, b, 2), [{indent, 2}, {space, 2}]))
       end},
 
+     %% `map_unknown_value` option
+     {"`map_unknown_value` option",
+      fun () ->
+              Input = [{1,2,3,4}],
+              MapFun = fun ({_,_,_,_} = Ip4) -> {ok, list_to_binary(inet:ntoa(Ip4))};
+                           (_)               -> error
+                       end,
+              Expected = <<"[\"1.2.3.4\"]">>,
+              ?assertEqual(Expected, jsone:encode(Input, [{map_unknown_value, MapFun}]))
+      end},
+
      %% Others
      {"compound data",
       fun () ->


### PR DESCRIPTION
This PR adds `map_unknown_value` encoding option. By this option, we can encode values that aren't supported by default as follows:
```erlang
> IpAddr = {127, 0, 0, 1}.
> MapFun = fun ({_,_,_,_} = Ip4) -> {ok, list_to_binary(inet:ntoa(Ip4))}; (_) -> error end.
> jsone:encode(#{<<"ipaddr">> => IpAddr}, [{map_unknown_value, MapFun}]).
<<"{\"ipaddr\":\"127.0.0.1\"}">>
```

See also https://github.com/sile/jsone/pull/49