### PR TITLE
Add `skip_undefined` encoding option

### DIFF
--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -197,6 +197,7 @@
                        | {space, non_neg_integer()}
                        | {indent, non_neg_integer()}
                        | {map_unknown_value, fun ((term()) -> {ok, json_value()} | error)}
+                       | skip_undefined
                        | common_option().
 %% `native_utf8': <br />
 %% - Encodes non ASCII UTF-8 characters as a human-readable(non-escaped) string <br />
@@ -230,6 +231,9 @@
 %% `{indent, N}': <br />
 %% - Inserts a newline and `N' spaces for each level of indentation <br />
 %% - default: `0' <br />
+%%
+%% `skip_undefined': <br />
+%% - If speficied, each entry having `undefined' value in a object isn't included in the result JSON <br />
 %%
 %% `{map_unknown_value, Fun}`: <br />
 %% - If specified, unknown values encountered during an encoding process are converted to `json_value()` by applying `Fun'.

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -262,6 +262,12 @@ encode_test_() ->
               ?assertEqual({ok,<<"null">>},          jsone_encode:encode(undefined,[undefined_as_null])), % OK
               ?assertEqual({ok,<<"\"undefined\"">>}, jsone_encode:encode(undefined,[])) % OK
       end},
+     {"skip_undefined option",
+      fun() ->
+              Object = #{<<"1">> => undefined, <<"2">> => 3},
+              ?assertEqual({ok,<<"{\"1\":null,\"2\":3}">>}, jsone_encode:encode(Object,[undefined_as_null])),
+              ?assertEqual({ok,<<"{\"2\":3}">>},            jsone_encode:encode(Object,[skip_undefined]))
+      end},
 
      %% Pretty Print
      {"space",


### PR DESCRIPTION
This PR adds `skip_undefined` encoding option which allows skipping to encode entries that have undefined values in objects.

# Example

```erlang
> Object = #{<<"1">> => undefined, <<"2">> => 3}.
> <<"{\"1\":null,\"2\":3}">> = jsone:encode(Object, [undefined_as_null]).
> <<"{\"2\":3}">>            = jsone:encode(Object, [skip_undefined])).
```