### PR TITLE
Fix a bug of `skip_undefined` encoding option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,7 @@
    ]},
   {test,
    [
+    {erl_opts, [debug_info]},
     {plugins, [covertool]}
    ]}
  ]}.

--- a/src/jsone_encode.erl
+++ b/src/jsone_encode.erl
@@ -323,18 +323,22 @@ array_values([],       Nexts, Buf, Opt) -> next(Nexts, <<(pp_newline(Buf, Nexts,
 array_values([X | Xs], Nexts, Buf, Opt) -> value(X, [{array_values, Xs} | Nexts], Buf, Opt).
 
 -spec object(jsone:json_object_members(), [next()], binary(), opt()) -> encode_result().
-object([],      Nexts, Buf, Opt) ->
-    next(Nexts, <<Buf/binary, ${, $}>>, Opt);
-object(Members, Nexts, Buf, ?OPT{canonical_form = true}=Opt) ->
-  object_members(lists:sort(Members), Nexts, pp_newline(<<Buf/binary, ${>>, Nexts, 1, Opt), Opt);
+object(Members, Nexts, Buf, ?OPT{skip_undefined = true}=Opt) ->
+    object1(lists:filter(fun ({_, V}) -> V =/= undefined end, Members), Nexts, Buf, Opt);
 object(Members, Nexts, Buf, Opt) ->
+    object1(Members, Nexts, Buf, Opt).
+
+-spec object1(jsone:json_object_members(), [next()], binary(), opt()) -> encode_result().
+object1([],      Nexts, Buf, Opt) ->
+    next(Nexts, <<Buf/binary, ${, $}>>, Opt);
+object1(Members, Nexts, Buf, ?OPT{canonical_form = true}=Opt) ->
+    object_members(lists:sort(Members), Nexts, pp_newline(<<Buf/binary, ${>>, Nexts, 1, Opt), Opt);
+object1(Members, Nexts, Buf, Opt) ->
     object_members(Members, Nexts, pp_newline(<<Buf/binary, ${>>, Nexts, 1, Opt), Opt).
 
 -spec object_members(jsone:json_object_members(), [next()], binary(), opt()) -> encode_result().
 object_members([], Nexts, Buf, Opt) ->
     next(Nexts, <<(pp_newline(Buf, Nexts, Opt))/binary, $}>>, Opt);
-object_members([{_, undefined} | Xs], Nexts, Buf, ?OPT{skip_undefined=true}=Opt) ->
-    object_members(Xs, Nexts, Buf, Opt);
 object_members([{Key, Value} | Xs], Nexts, Buf, Opt) ->
     object_key(Key, [{object_value, Value, Xs} | Nexts], Buf, Opt);
 object_members(Arg, Nexts, Buf, Opt) ->

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -264,9 +264,9 @@ encode_test_() ->
       end},
      {"skip_undefined option",
       fun() ->
-              Object = #{<<"1">> => undefined, <<"2">> => 3},
-              ?assertEqual({ok,<<"{\"1\":null,\"2\":3}">>}, jsone_encode:encode(Object,[undefined_as_null])),
-              ?assertEqual({ok,<<"{\"2\":3}">>},            jsone_encode:encode(Object,[skip_undefined]))
+              Object = #{<<"1">> => undefined, <<"2">> => 3, <<"3">> => undefined},
+              ?assertEqual({ok,<<"{\"1\":null,\"2\":3,\"3\":null}">>}, jsone_encode:encode(Object,[undefined_as_null])),
+              ?assertEqual({ok,<<"{\"2\":3}">>},                       jsone_encode:encode(Object,[skip_undefined]))
       end},
 
      %% Pretty Print


### PR DESCRIPTION
The `skip_undefined` option, which introduced by #53, has a bug such that if an entry having the `undefined` value is placed at the last in an object, the encoded JSON object has an extra comma as follows:
```erlang
> jsone:encode(#{a => [#{a => undefined, b => c, d => undefined}]}, [skip_undefined]).
<<"{\"a\":[{\"b\":\"c\",}]}">> 
```

This PR fixes the bug.