### PR TITLE
Don't try to encode singleton tuples as objects.

### DIFF
--- a/src/jsone_encode.erl
+++ b/src/jsone_encode.erl
@@ -138,7 +138,7 @@ value(Value, Nexts, Buf, Opt) when is_integer(Value) -> next(Nexts, <<Buf/binary
 value(Value, Nexts, Buf, Opt) when is_float(Value)   -> next(Nexts, <<Buf/binary, (float_to_binary(Value, Opt?OPT.float_format))/binary>>, Opt);
 value(Value, Nexts, Buf, Opt) when ?IS_STR(Value)    -> string(Value, Nexts, Buf, Opt);
 value({{_,_,_},{_,_,_}} = Value, Nexts, Buf, Opt)    -> datetime(Value, Nexts, Buf, Opt);
-value({Value}, Nexts, Buf, Opt)                      -> object(Value, Nexts, Buf, Opt);
+value({Value}, Nexts, Buf, Opt) when is_list(Value)  -> object(Value, Nexts, Buf, Opt);
 value([{}], Nexts, Buf, Opt)                         -> object([], Nexts, Buf, Opt);
 value([{{_,_,_},{_,_,_}}|_] = Value, Nexts, Buf, Opt)-> array(Value, Nexts, Buf, Opt);
 value([{_, _}|_] = Value, Nexts, Buf, Opt)           -> object(Value, Nexts, Buf, Opt);

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -308,6 +308,14 @@ encode_test_() ->
               Expected = <<"[\"1.2.3.4\"]">>,
               ?assertEqual(Expected, jsone:encode(Input, [{map_unknown_value, MapFun}]))
       end},
+     {"`map_unknown_value` option with singleton tuple",
+      fun () ->
+              Input = [{foo}],
+              MapFun = fun (Value) -> {ok, unicode:characters_to_binary(io_lib:format("~p~n", [Value]))}
+                       end,
+              Expected = <<"[\"{foo}\\n\"]">>,
+              ?assertEqual(Expected, jsone:encode(Input, [{map_unknown_value, MapFun}]))
+      end},
 
      %% Others
      {"compound data",


### PR DESCRIPTION
Previously, trying to encode any tuples with a single value inside
causes a `badarg` to be raised, as it's being interpreted as an
"object", which is expected to be a _list_ of pairs instead.

Other tuples are already let fall through to the unknown value head,
which calls the `map_unknown_value` callback, if provided.

This change makes it so that single-value tuples (singleton tuples) are
also let fall through, so that they can be handled by the callback, so
that they become the caller's responsibility to encode.