### PR TITLE
Fix incorrect regex in platform_define

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             warn_untyped_record,
             inline,
             {platform_define, "^R[01][0-9]", 'NO_MAP_TYPE'},
-            {platform_define, "(^R|17)", 'NO_DIALYZER_SPEC'}
+            {platform_define, "^(R|17)", 'NO_DIALYZER_SPEC'}
            ]}.
 
 {xref_checks, [


### PR DESCRIPTION
This broken regex will match against "17" anywhere in the OTP version string, and so will define NO_DIALYZER_SPEC also for newer OTP versions, e.g. 22.3.4.17.