### PR TITLE
Use covertool as a project_plugin, rather than plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,6 +53,6 @@
   {test,
    [
     {erl_opts, [debug_info]},
-    {plugins, [covertool]}
+    {project_plugins, [covertool]}
    ]}
  ]}.


### PR DESCRIPTION
This was resulting in `covertool` being pulled-in as a dependency needlessly in downstream projects in some situations.

Using it as a `project_plugin` is advised by `covertool` [itself](https://github.com/covertool/covertool#rebar3).

More on plugins vs project plugins: https://rebar3.readme.io/docs/using-available-plugins