### PR TITLE
Reduce floating point errors in decoding

### DIFF
--- a/src/jsone_decode.erl
+++ b/src/jsone_decode.erl
@@ -283,7 +283,11 @@ number_exponation_part(<<C, Bin/binary>>, N, DecimalOffset, ExpSign, Exp, _, Nex
     number_exponation_part(Bin, N, DecimalOffset, ExpSign, Exp * 10 + C - $0, false, Nexts, Buf, Opt);
 number_exponation_part(<<Bin/binary>>, N, DecimalOffset, ExpSign, Exp, false, Nexts, Buf, Opt) ->
     Pos = ExpSign * Exp - DecimalOffset,
-    try N * math:pow(10, Pos)
+    try
+        case Pos of
+            Pos when Pos >= 0 -> N * math:pow(10, Pos);
+            _                 -> N / math:pow(10, -Pos) % multiplying by decimal makes float errors larger.
+        end
     of Res -> next(Bin, Res, Nexts, Buf, Opt)
     catch error:badarith ->
         ?ERROR(number_exponation_part, [Bin, N, DecimalOffset, ExpSign, Exp, false, Nexts, Buf, Opt])

--- a/test/jsone_decode_tests.erl
+++ b/test/jsone_decode_tests.erl
@@ -77,7 +77,8 @@ decode_test_() ->
               ?assertEqual({ok, 12.345, <<"">>}, jsone_decode:decode(<<"0.12345E2">>)),
               ?assertEqual({ok, 12.345, <<"">>}, jsone_decode:decode(<<"0.12345e+2">>)), % exponent part can begin with plus sign
               ?assertEqual({ok, 12.345, <<"">>}, jsone_decode:decode(<<"0.12345E+2">>)),
-              ?assertEqual({ok, -12.345, <<"">>}, jsone_decode:decode(<<"-0.012345e3">>))
+              ?assertEqual({ok, -12.345, <<"">>}, jsone_decode:decode(<<"-0.012345e3">>)),
+              ?assertEqual({ok, 123.0, <<"">>}, jsone_decode:decode(<<"1.23000000000000000000e+02">>))
       end},
      {"float: invalid format",
       fun () ->


### PR DESCRIPTION
Before:
```
1> Json = jsone:encode(123.0).
<<"1.23000000000000000000e+02">>
2> jsone:decode(Json).
123.00000000000001
```

After:
```
1> Json = jsone:encode(123.0).
<<"1.23000000000000000000e+02">>
2> jsone:decode(Json).
123.0
```

Although floating point numbers may have errors, numbers which can be represented without errors should be treated without errors. This patch reduce floating point errors by avoiding the use of decimals.

```
1> 123000000000000000000.0 * 1.0e-18.
123.00000000000001
2> 123000000000000000000.0 / 1.0e+18.
123.0
```

In spite of that 123000000000000000000 &gt; 2<sup>53</sup>, 123000000000000000000 can be exactly represented in IEEE 754 format since it can be divided by 2 many times.

My concern is performance. Division may be slower than multiplication.

My coworker wrote this patch and he has agreed to post it here.