### PR TITLE
Don't insert newlines when encoding unknown terms using `jsone:term_to_json_string/1`

### DIFF
--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -424,7 +424,7 @@ try_encode(JsonValue, Options) ->
 %% @doc Converts the given term `X' to its string representation (i.e., the result of `io_lib:format("~p", [X])').
 -spec term_to_json_string(term()) -> {ok, json_string()} | error.
 term_to_json_string(X) ->
-    {ok, list_to_binary(io_lib:format("~p", [X]))}.
+    {ok, list_to_binary(io_lib:format("~0p", [X]))}.
 
 
 %% @doc Convert an IP address into a text representation.


### PR DESCRIPTION
### Before (master branch)

```erlang
> jsone:encode(list_to_tuple([{I,self()} || I <- lists:seq(1,6)])).
<<"\"{{1,<0.199.0>},\\n {2,<0.199.0>},\\n {3,<0.199.0>},\\n {4,<0.199.0>},\\n {5,<0.199.0>},\\n {6,<0.199.0>}}\"">>
```

### After (This PR)

```erlang
> jsone:encode(list_to_tuple([{I,self()} || I <- lists:seq(1,6)])).
<<"\"{{1,<0.191.0>},{2,<0.191.0>},{3,<0.191.0>},{4,<0.191.0>},{5,<0.191.0>},{6,<0.191.0>}}\"">>
```