### PR TITLE
Fix `jsone:try_encode({{json_utf8, IncompleteUtf8}})` raises a `try_clause` exception.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp: ['24.0', '25.0']
+        otp: ['24.0', '25.0', '26.0']
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -31,7 +31,7 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '25.0'

--- a/src/jsone_encode.erl
+++ b/src/jsone_encode.erl
@@ -143,6 +143,9 @@ value({{json_utf8, T}}, Nexts, Buf, Opt) ->
         {error, OK, Invalid} ->
             {error, {{invalid_json_utf8, OK, Invalid},
                      [{?MODULE, value, [{json_utf8, T}, Nexts, Buf, Opt], [{line, ?LINE}]}]}};
+        {incomplete, OK, Incomplete} ->
+            {error, {{invalid_json_utf8, OK, Incomplete},
+                     [{?MODULE, value, [{json_utf8, T}, Nexts, Buf, Opt], [{line, ?LINE}]}]}};
         B when is_binary(B) ->
             next(Nexts, <<Buf/binary, B/binary>>, Opt)
     catch

--- a/test/jsone_encode_tests.erl
+++ b/test/jsone_encode_tests.erl
@@ -38,7 +38,11 @@ encode_test_() ->
                                                      <<"bar">>,
                                                      {{json, [$", 233, "ok", $"]}}))),
               ?assertEqual({ok, <<"{\"json\":\"[1,2,3]\"}">>}, jsone_encode:encode([{json, <<"[1,2,3]">>}])),
-              ?assertEqual({ok, <<"[[1,2,3]]">>}, jsone_encode:encode([{{json, <<"[1,2,3]">>}}]))
+              ?assertEqual({ok, <<"[[1,2,3]]">>}, jsone_encode:encode([{{json, <<"[1,2,3]">>}}])),
+
+              %% Errors
+              ?assertMatch({error, {{invalid_json_utf8, _, _}, _}}, jsone_encode:encode({{json_utf8, <<200, 83, 1>>}})),
+              ?assertMatch({error, {{invalid_json_utf8, _, _}, _}}, jsone_encode:encode({{json_utf8, <<"abc", 192>>}}))
       end},
      %% Numbers: Integer
      {"zero", fun() -> ?assertEqual({ok, <<"0">>}, jsone_encode:encode(0)) end},


### PR DESCRIPTION
`{{jsone_utf8, _}}` feature was introduced in #11, but it turned out that the current implementation doesn't consider that `unicode:characters_to_binary/1` could return `{incomplete, _, _}` tuple as the result. 
If the tuple is returned, `try_encode()` method raises an (unintended) exception.
This PR fixes this problem.