### PR TITLE
Remove `Enable HiPE` section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,6 @@ $ make start
 [1,2,3]
 ```
 
-Enable HiPE
------------
-
-If you want to use HiPE compiled version, please add following code to your rebar.config.
-
-```erlang
-{overrides,
-  [
-    {override, jsone, [{erl_opts, [{d, 'ENABLE_HIPE'}, inline]}]}
-  ]}.
-```
-
-or use `native` profile. The `make` command supports profile as well. For example:
-
-```sh
-$ make start profile=native
-```
-
 Usage Example
 -------------
 


### PR DESCRIPTION
HiPE features are no longer recommended as a way to improve performance. For more details, please see https://www.erlang.org/blog/the-road-to-the-jit/.

Copilot Summary
-------------------

This pull request includes a small change to the `README.md` file. The change removes the section about enabling HiPE, simplifying the documentation.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-L66): Removed the section about enabling HiPE and using the `native` profile.
